### PR TITLE
fix(auth): gestionnaire_salle role alignment, tighter UserRole types, AuthContext cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,7 +201,7 @@ const buildNavSections = (user: User): NavSection[] => {
   const sections: NavSection[] = [];
   if (user.roles.includes('organisateur')) sections.push({ label: 'Organisateur', items: [...] });
   if (user.roles.includes('prestataire'))  sections.push({ label: 'Prestataire',  items: [...] });
-  if (user.roles.includes('gestionnaire')) sections.push({ label: 'Gestionnaire', items: [...] });
+  if (user.roles.includes('gestionnaire_salle')) sections.push({ label: 'Gestionnaire', items: [...] });
   if (user.roles.includes('participant'))  sections.push({ label: 'Participant',  items: [...] });
   // Commun à tous
   sections.push({ label: '', items: [favoris, decouvrir, parametres] });

--- a/src/app/(auth)/inscription/page.tsx
+++ b/src/app/(auth)/inscription/page.tsx
@@ -8,6 +8,7 @@ import { RegisterStep1Form, type Step1Data } from "@/features/auth/components/Re
 import { RegisterStep2RoleSelector } from "@/features/auth/components/RegisterStep2RoleSelector";
 import { authService } from "@/features/auth/client/auth.service";
 import { useAuth } from "@/shared/hooks/useAuth";
+import type { UserRole } from "@/shared/types";
 
 const stepOut = { x: 0, opacity: 0, transition: { duration: 0.2, ease: "easeIn" as const } };
 const step2Enter = { x: 40, opacity: 0 };
@@ -26,7 +27,7 @@ export default function InscriptionPage() {
     setStep(2);
   };
 
-  const handleRegister = async (role: string) => {
+  const handleRegister = async (role: UserRole) => {
     if (!step1Data) return;
     const session = await authService.register({ ...step1Data, role }).catch((err: unknown) => {
       const authErr = err as { code?: string };

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -27,8 +27,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    setRefreshTokenFn(() => authService.refreshAccessToken());
-
     authService
       .refreshSession()
       .then((restoredSession) => {

--- a/src/features/auth/client/auth.service.ts
+++ b/src/features/auth/client/auth.service.ts
@@ -5,7 +5,7 @@ import type { AuthSession, User, UserRole } from "@/shared/types";
 const USER_ROLES: UserRole[] = [
   "organisateur",
   "prestataire",
-  "gestionnaire",
+  "gestionnaire_salle",
   "participant",
 ];
 

--- a/src/features/auth/client/auth.service.ts
+++ b/src/features/auth/client/auth.service.ts
@@ -96,7 +96,7 @@ export interface RegisterData {
   fullName: string;
   email: string;
   password: string;
-  role: string;
+  role: UserRole;
 }
 
 export const authService = {

--- a/src/features/auth/components/RegisterStep2RoleSelector.tsx
+++ b/src/features/auth/components/RegisterStep2RoleSelector.tsx
@@ -4,15 +4,17 @@ import { useState } from "react";
 import Link from "next/link";
 import { motion } from "framer-motion";
 import { Calendar, Star, Building2, Loader2 } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import type { UserRole } from "@/shared/types";
 import { RoleCard } from "./RoleCard";
 import { StepIndicator } from "./StepIndicator";
 import { cn } from "@/shared/lib/utils";
 
 interface RegisterStep2Props {
-  onSubmit: (role: string) => Promise<void>;
+  onSubmit: (role: UserRole) => Promise<void>;
 }
 
-const roleCards = [
+const roleCards: { value: UserRole; icon: LucideIcon; iconBg: string; iconColor: string; title: string; description: string }[] = [
   {
     value: "organisateur",
     icon: Calendar,
@@ -50,7 +52,7 @@ const item = {
 };
 
 export function RegisterStep2RoleSelector({ onSubmit }: RegisterStep2Props) {
-  const [selectedRole, setSelectedRole] = useState("organisateur");
+  const [selectedRole, setSelectedRole] = useState<UserRole>("organisateur");
   const [isLoading, setIsLoading] = useState(false);
 
   const handleSubmit = async () => {

--- a/src/features/auth/components/RegisterStep2RoleSelector.tsx
+++ b/src/features/auth/components/RegisterStep2RoleSelector.tsx
@@ -30,7 +30,7 @@ const roleCards = [
     description: "Offrez vos services (traiteur, son, déco).",
   },
   {
-    value: "gestionnaire",
+    value: "gestionnaire_salle",
     icon: Building2,
     iconBg: "#FEF3C7",
     iconColor: "#C8862A",

--- a/src/features/auth/components/RoleCard.tsx
+++ b/src/features/auth/components/RoleCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { LucideIcon } from "lucide-react";
+import type { UserRole } from "@/shared/types";
 import { cn } from "@/shared/lib/utils";
 
 interface RoleCardProps {
@@ -9,9 +10,9 @@ interface RoleCardProps {
   iconColor: string;
   title: string;
   description: string;
-  value: string;
+  value: UserRole;
   selected: boolean;
-  onSelect: (value: string) => void;
+  onSelect: (value: UserRole) => void;
 }
 
 export function RoleCard({

--- a/src/shared/layout/sidebar-nav.test.ts
+++ b/src/shared/layout/sidebar-nav.test.ts
@@ -44,7 +44,7 @@ describe("buildNavSections", () => {
     const sections = buildNavSections([
       "organisateur",
       "prestataire",
-      "gestionnaire",
+      "gestionnaire_salle",
       "participant",
     ]);
     sections.forEach((section) => {

--- a/src/shared/layout/sidebar-nav.ts
+++ b/src/shared/layout/sidebar-nav.ts
@@ -104,7 +104,7 @@ export function buildNavSections(
     });
   }
 
-  if (roles.includes("gestionnaire")) {
+  if (roles.includes("gestionnaire_salle")) {
     sections.push({
       label: "Gestionnaire de lieu",
       items: [

--- a/src/shared/types/user.types.ts
+++ b/src/shared/types/user.types.ts
@@ -1,7 +1,7 @@
 export type UserRole =
   | "organisateur"
   | "prestataire"
-  | "gestionnaire"
+  | "gestionnaire_salle"
   | "participant";
 
 export interface User {


### PR DESCRIPTION
## Problèmes corrigés

Suite à un audit auth complet (sécurité + qualité) avant Plan B.

### 🔴 Bloquant — Désalignement de rôle
- `UserRole` type : `"gestionnaire"` → `"gestionnaire_salle"` (`shared/types/user.types.ts`)
- `USER_ROLES` array mis à jour (`features/auth/client/auth.service.ts`)
- `RegisterStep2RoleSelector` : valeur de la carte "Gestionnaire de lieu" corrigée
- `sidebar-nav.ts` : `roles.includes("gestionnaire")` → `roles.includes("gestionnaire_salle")`
- Sans ce fix, l'inscription "Gestionnaire de lieu" envoyait `roles: ["gestionnaire"]` → rejeté par l'API (400)

### 🟡 Nettoyage TypeScript
- `RegisterData.role` : `string` → `UserRole`
- `RegisterStep2Props.onSubmit` : `(role: string)` → `(role: UserRole)`
- `RoleCard` props `value`/`onSelect` : `string` → `UserRole`
- `inscription/page.tsx` mis à jour en cascade

### 🟡 AuthContext
- Suppression du `setRefreshTokenFn` redondant dans le premier `useEffect` (le second `useEffect` avec `[logout]` faisait la même chose et écrasait le premier)

### 📄 Documentation
- `CLAUDE.md` corrigé : `'gestionnaire'` → `'gestionnaire_salle'` dans l'exemple sidebar

## Vérification
- ✅ `tsc --noEmit` — 0 erreur

🤖 Generated with [Claude Code](https://claude.com/claude-code)